### PR TITLE
feat: Add Teams Page

### DIFF
--- a/gemini-meta-err-20250919074158.log
+++ b/gemini-meta-err-20250919074158.log
@@ -1,0 +1,2 @@
+(node:1831384) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)

--- a/gemini-meta-out-20250919074158.txt
+++ b/gemini-meta-out-20250919074158.txt
@@ -1,0 +1,8 @@
+```json
+{
+  "branch_name": "feat/agent-add-teams-page",
+  "commit_message": "feat: Add standard teams page with member profiles",
+  "pr_title": "feat: Add Teams Page",
+  "pr_body": "This PR introduces a new 'Teams' page to display our team members. The page is designed to be visually appealing and follows standard layout conventions.\n\n**Changes:**\n- Added a new page for team member profiles.\n- Populated the page with placeholder team members, using Nordic/Aryan names, random mobile numbers, emails, and other dummy information.\n\n**Review Notes:**\n- The current team member data (names, contact info, etc.) are placeholders and will need to be replaced with actual team information.\n- Please review the overall design and responsiveness of the page."
+}
+```

--- a/gemini-tool-err-20250919074158.log
+++ b/gemini-tool-err-20250919074158.log
@@ -1,0 +1,2 @@
+(node:1832720) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Link from "next/link"; // Import Link
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,25 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <nav className="bg-gray-800 p-4">
+          <div className="container mx-auto flex justify-between items-center">
+            <Link href="/" className="text-white text-2xl font-bold">
+              Our Company
+            </Link>
+            <ul className="flex space-x-6">
+              <li>
+                <Link href="/" className="text-gray-300 hover:text-white text-lg">
+                  Home
+                </Link>
+              </li>
+              <li>
+                <Link href="/team" className="text-gray-300 hover:text-white text-lg">
+                  Our Team
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </nav>
         {children}
       </body>
     </html>

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,0 +1,112 @@
+
+import React from 'react';
+
+interface TeamMember {
+  id: number;
+  name: string;
+  role: string;
+  email: string;
+  phone: string;
+  image: string; // Placeholder for an image
+}
+
+const teamMembers: TeamMember[] = [
+  {
+    id: 1,
+    name: 'Bjorn Ironside',
+    role: 'CEO & Founder',
+    email: 'bjorn.ironside@example.com',
+    phone: '+1 (555) 123-4567',
+    image: 'https://via.placeholder.com/150/cccccc/ffffff?text=BI',
+  },
+  {
+    id: 2,
+    name: 'Freya Valkyrie',
+    role: 'Chief Technology Officer',
+    email: 'freya.valkyrie@example.com',
+    phone: '+1 (555) 987-6543',
+    image: 'https://via.placeholder.com/150/cccccc/ffffff?text=FV',
+  },
+  {
+    id: 3,
+    name: 'Erik the Red',
+    role: 'Head of Product',
+    email: 'erik.thered@example.com',
+    phone: '+1 (555) 234-5678',
+    image: 'https://via.placeholder.com/150/cccccc/ffffff?text=ER',
+  },
+  {
+    id: 4,
+    name: 'Astrid Shieldmaiden',
+    role: 'Lead Designer',
+    email: 'astrid.shieldmaiden@example.com',
+    phone: '+1 (555) 876-5432',
+    image: 'https://via.placeholder.com/150/cccccc/ffffff?text=AS',
+  },
+  {
+    id: 5,
+    name: 'Ragnar Lothbrok',
+    role: 'Marketing Director',
+    email: 'ragnar.lothbrok@example.com',
+    phone: '+1 (555) 345-6789',
+    image: 'https://via.placeholder.com/150/cccccc/ffffff?text=RL',
+  },
+  {
+    id: 6,
+    name: 'Ingrid Stormborn',
+    role: 'HR Manager',
+    email: 'ingrid.stormborn@example.com',
+    phone: '+1 (555) 765-4321',
+    image: 'https://via.placeholder.com/150/cccccc/ffffff?text=IS',
+  },
+];
+
+const TeamPage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-100 py-12">
+      <div className="container mx-auto px-4">
+        <h1 className="text-5xl font-extrabold text-center text-gray-900 mb-12">Our Esteemed Team</h1>
+        <p className="text-xl text-center text-gray-700 mb-16 max-w-3xl mx-auto">
+          Meet the brilliant minds behind our success. Each member brings unique skills and passion to our mission, driving innovation and excellence.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
+          {teamMembers.map((member) => (
+            <div
+              key={member.id}
+              className="bg-white rounded-xl shadow-lg overflow-hidden transform transition duration-500 hover:scale-105 hover:shadow-2xl"
+            >
+              <div className="relative h-48 bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
+                <img
+                  className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 h-32 w-32 rounded-full object-cover border-4 border-white shadow-md"
+                  src={member.image}
+                  alt={member.name}
+                />
+              </div>
+              <div className="pt-20 pb-8 px-6 text-center">
+                <h2 className="text-3xl font-bold text-gray-900 mb-2">{member.name}</h2>
+                <p className="text-lg text-purple-700 font-semibold mb-4">{member.role}</p>
+                <div className="text-gray-600 text-base space-y-2">
+                  <p>
+                    <strong className="text-gray-800">Email:</strong>{' '}
+                    <a href={`mailto:${member.email}`} className="text-blue-600 hover:underline">
+                      {member.email}
+                    </a>
+                  </p>
+                  <p>
+                    <strong className="text-gray-800">Phone:</strong>{' '}
+                    <a href={`tel:${member.phone}`} className="text-blue-600 hover:underline">
+                      {member.phone}
+                    </a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeamPage;


### PR DESCRIPTION
This PR introduces a new 'Teams' page to display our team members. The page is designed to be visually appealing and follows standard layout conventions.

**Changes:**
- Added a new page for team member profiles.
- Populated the page with placeholder team members, using Nordic/Aryan names, random mobile numbers, emails, and other dummy information.

**Review Notes:**
- The current team member data (names, contact info, etc.) are placeholders and will need to be replaced with actual team information.
- Please review the overall design and responsiveness of the page.